### PR TITLE
Fix the process is not received SIGNAL.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,4 +25,4 @@ if [ -v GENESIS_BLOCK_WITH_SIG -a ! -e ${DATA_DIR}/genesis.${network_id} ]; then
   echo ${GENESIS_BLOCK_WITH_SIG} > ${DATA_DIR}/genesis.${network_id}
 fi
 
-exec sh -c "$*"
+exec bash -c "$*"


### PR DESCRIPTION
Before
```bash
root@37fd6096cf62:/# ps x
  PID TTY      STAT   TIME COMMAND
    1 ?        SLsl   0:00 sh -c tapyrusd -datadir=${DATA_DIR} -conf=${CONF_DIR}/tapyrus.conf
   11 ?        SLsl   0:00 tapyrusd -datadir=/var/lib/tapyrus -conf=/etc/tapyrus/tapyrus.conf
   47 pts/0    Ss     0:00 bash
   60 pts/0    R+     0:00 ps x
```

After
```bash
root@fc4e4a3b279e:/# ps x
  PID TTY      STAT   TIME COMMAND
    1 ?        SLsl   0:00 tapyrusd -datadir=/var/lib/tapyrus -conf=/etc/tapyrus/tapyrus.conf
   47 pts/0    Ss     0:00 bash
   60 pts/0    R+     0:00 ps x
```